### PR TITLE
Spaces allowed in tag names if they are contained in parens

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Version 1:
     Tabs are used to indent.
     Each task begins with a "- ".
     Projects end with a ":".
-    Tags are in the format "@tag_name".
+    Tags are in the format "@tag_name" or "@tag(value)".
     All other lines (such as these) are considered as notes,
     and are to be ignored.
 
@@ -24,7 +24,7 @@ Version 1:
 
     - Manage users
         - Create users @in_progress
-        - Delete users
+        - Delete users @priority(1)
         - User profile page @40%
 
     - Blog

--- a/es5/index.js
+++ b/es5/index.js
@@ -14,7 +14,7 @@ var INDENT = P.regex(/[\t\s]+/)
  *     "@done"
  */
 
-var TAG = P.regex(/@([^\s\n]+)/, 1)
+var TAG = P.regex(/@([^\(\s]+(\([^\)]+\))?)/, 1)
 
 /*
  * A string without @tags

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const INDENT = P.regex(/[\t\s]+/)
  *     "@done"
  */
 
-const TAG = P.regex(/@([^\s\n]+)/, 1)
+const TAG = P.regex(/@([^\(\s]+(\([^\)]*\))?)/, 1)
 
 /*
  * A string without @tags

--- a/test.js
+++ b/test.js
@@ -39,6 +39,12 @@ test('task tags, multiple', t => {
   t.end()
 })
 
+test('task tags with spaces inside parentheses', t => {
+  result = parse('- Task name @one(a and b) @two @three()')
+  t.deepEqual(result.children[0].tags, ['one(a and b)', 'two', 'three()'])
+  t.end()
+})
+
 test('notes', t => {
   result = parse('Hello world')
   t.deepEqual(result.children[0].value, 'Hello world\n')


### PR DESCRIPTION
The taskpaper format allows for tags to contain values if they are embedded inside parentheses.  (ex. `@start(2017-09-26)`).  Furthermore, spaces are allowed in this value, as well (ex. `@tag(spaces allowed)`)

This proposed change modifies the TAG regex to account for this use of parentheses.